### PR TITLE
fix wristwatch link

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -3214,7 +3214,7 @@ export const Canning = {
 export const Wristwatch = {
   "id": "wristwatch",
   "text": "Wristwatch",
-  "source": "https://en.wikipedia.org/wiki/https://en.wikipedia.org",
+  "source": "https://en.wikipedia.org/wiki/Watch#Wristwatches",
   "slim": "W",
   "descriptive": "Wr",
   "verbose": "Wr",


### PR DESCRIPTION
The link to "wristwatch" is broken. Proposed fix links to the `Wristwatches` section on the [Watch Wikipedia page](https://en.wikipedia.org/wiki/Watch) which contains reference to the year 1810.